### PR TITLE
Add standalone RAG vector search script

### DIFF
--- a/rag_vector_search.py
+++ b/rag_vector_search.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Self-contained RAG vector search."""
+
+from __future__ import annotations
+
+import os
+import sys
+import json
+from typing import List, Dict
+
+import numpy as np
+
+try:
+    import faiss  # type: ignore
+except Exception:  # pragma: no cover
+    print("faiss not installed", file=sys.stderr)
+    raise
+
+try:
+    import tiktoken
+    ENC = tiktoken.encoding_for_model("text-embedding-3-small")
+except Exception:  # pragma: no cover - allow offline usage
+    class _DummyEnc:
+        def encode(self, text: str):
+            return text.split()
+
+        def decode(self, tokens):
+            return " ".join(tokens)
+
+    ENC = _DummyEnc()
+from pdfminer.high_level import extract_text as pdf_extract_text
+from docx import Document
+
+try:
+    import openai
+except Exception:
+    openai = None  # type: ignore
+
+try:
+    from sentence_transformers import SentenceTransformer  # type: ignore
+except Exception:
+    SentenceTransformer = None  # type: ignore
+
+# Global resources
+INDEX: faiss.IndexFlatIP | None = None
+META: List[Dict] = []
+ST_MODEL: SentenceTransformer | None = None
+
+
+def load_file(path: str) -> str:
+    ext = os.path.splitext(path)[1].lower()
+    try:
+        if ext in {".txt", ".md"}:
+            with open(path, "r", encoding="utf-8") as f:
+                return f.read()
+        if ext == ".pdf":
+            return pdf_extract_text(path)
+        if ext == ".docx":
+            return "\n".join(p.text for p in Document(path).paragraphs)
+    except Exception as e:  # pragma: no cover - handle below
+        raise RuntimeError(f"Failed to read {path}: {e}")
+    raise RuntimeError(f"Unsupported file type: {path}")
+
+
+def chunk_text(text: str, chunk_size: int = 500, overlap: int = 20) -> List[str]:
+    tokens = ENC.encode(text)
+    chunks: List[str] = []
+    for i in range(0, len(tokens), chunk_size - overlap):
+        chunk_tokens = tokens[i : i + chunk_size]
+        chunks.append(ENC.decode(chunk_tokens))
+    return chunks
+
+
+def embed_texts(texts: List[str]) -> np.ndarray:
+    global ST_MODEL
+    if os.getenv("FAKE_EMBEDDINGS"):
+        arr = np.array([[hash(t) % 1000] for t in texts], dtype=np.float32)
+    elif os.getenv("OPENAI_API_KEY") and openai is not None:
+        res = openai.embeddings.create(
+            input=texts,
+            model="text-embedding-3-small",
+            encoding_format="float",
+        )
+        arr = np.array([r.embedding for r in res.data], dtype=np.float32)
+    else:
+        if SentenceTransformer is None:
+            raise RuntimeError("sentence-transformers not available")
+        if ST_MODEL is None:
+            ST_MODEL = SentenceTransformer("all-MiniLM-L6-v2")
+        arr = ST_MODEL.encode(texts, batch_size=512, show_progress_bar=False)
+    norms = np.linalg.norm(arr, axis=1, keepdims=True)
+    arr = arr / np.clip(norms, 1e-10, None)
+    return arr.astype("float32")
+
+
+def build_index(files: List[str]) -> None:
+    global INDEX, META
+    all_chunks: List[str] = []
+    meta: List[Dict] = []
+    for fname in files:
+        try:
+            text = load_file(fname)
+        except Exception as e:
+            print(e, file=sys.stderr)
+            sys.exit(1)
+        chunks = chunk_text(text)
+        for cid, chunk in enumerate(chunks):
+            char_start = text.find(chunk)
+            char_end = char_start + len(chunk)
+            meta.append(
+                {
+                    "filename": os.path.basename(fname),
+                    "chunk_id": cid,
+                    "char_start": char_start,
+                    "char_end": char_end,
+                }
+            )
+        all_chunks.extend(chunks)
+    embeds = embed_texts(all_chunks)
+    INDEX = faiss.IndexFlatIP(embeds.shape[1])
+    INDEX.add(embeds)
+    META = meta
+    size_bytes = embeds.nbytes
+    if size_bytes > 1_000_000_000:
+        print(
+            f"Index uses {size_bytes / 1_000_000:.2f} MB RAM. Consider using an IVF-PQ index.",
+            file=sys.stderr,
+        )
+
+
+def query(text: str, k: int = 5) -> List[Dict]:
+    if INDEX is None:
+        raise RuntimeError("Index not built")
+    vec = embed_texts([text])
+    distances, indices = INDEX.search(vec, k)
+    results = []
+    for score, idx in zip(distances[0], indices[0]):
+        if idx == -1:
+            continue
+        item = META[idx].copy()
+        item["score"] = float(score)
+        results.append(item)
+    results.sort(key=lambda x: x["score"], reverse=True)
+    return results
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python rag_vector_search.py <files...>", file=sys.stderr)
+        sys.exit(1)
+    build_index(sys.argv[1:])
+    print("Ready. Enter queries (Ctrl-D to exit).")
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        hits = query(line)
+        print(json.dumps(hits, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rag_vector_search.py
+++ b/tests/test_rag_vector_search.py
@@ -1,0 +1,72 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+os.environ["FAKE_EMBEDDINGS"] = "1"
+import json
+import subprocess
+
+import rag_vector_search as rvs
+
+
+def test_load_file_txt(tmp_path):
+    path = tmp_path / 'a.txt'
+    path.write_text('hello')
+    assert rvs.load_file(str(path)) == 'hello'
+
+
+def test_load_file_md(tmp_path):
+    path = tmp_path / 'a.md'
+    path.write_text('# title')
+    assert rvs.load_file(str(path)) == '# title'
+
+
+def test_load_file_pdf(tmp_path):
+    from reportlab.pdfgen import canvas
+
+    pdf_path = tmp_path / 'a.pdf'
+    c = canvas.Canvas(str(pdf_path))
+    c.drawString(10, 750, 'pdf text')
+    c.save()
+    text = rvs.load_file(str(pdf_path))
+    assert 'pdf text' in text
+
+
+def test_load_file_docx(tmp_path):
+    from docx import Document
+
+    path = tmp_path / 'a.docx'
+    doc = Document()
+    doc.add_paragraph('docx text')
+    doc.save(str(path))
+    text = rvs.load_file(str(path))
+    assert 'docx text' in text
+
+
+def test_build_query(tmp_path):
+    txt = tmp_path / 'a.txt'
+    txt.write_text('hello world. testing text.')
+    rvs.build_index([str(txt)])
+    results = rvs.query('testing', k=1)
+    assert results
+    assert results[0]['filename'] == txt.name
+
+
+def test_cli(tmp_path):
+    txt = tmp_path / 'b.txt'
+    txt.write_text('some cli text about testing.')
+    cmd = [sys.executable, 'rag_vector_search.py', str(txt)]
+    env = dict(os.environ)
+    env["FAKE_EMBEDDINGS"] = "1"
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, env=env)
+    out, _ = proc.communicate(b'testing\n', timeout=10)
+    lines = out.decode().splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith('['))
+    json_data = "\n".join(lines[start:])
+    data = json.loads(json_data)
+    assert isinstance(data, list)
+    assert data
+    assert data[0]['filename'] == txt.name
+
+
+


### PR DESCRIPTION
## Summary
- implement `rag_vector_search.py` to provide simple RAG pipeline
- include helpers for ingesting text/pdf/docx files, chunking with tiktoken, embedding via OpenAI or SentenceTransformer, and querying a FAISS vector index
- add offline fallback for embeddings and tokenization
- add unit and integration tests for document ingestion, indexing, and CLI queries

## Testing
- `ruff check rag_vector_search.py tests/test_rag_vector_search.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6847457fa98c832e9f04fc8abf62800d