### PR TITLE
Add utility to generate innate-in nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+package-lock.json
+generated-nodes
+sample-api.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # Configurable-RAG
+
+This repository includes utilities for creating custom **innate-in** nodes from existing REST APIs.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Generate a node from an OpenAPI specification:
+   ```bash
+   npm run generate path/to/openapi.json my-node-name
+   ```
+   The generated package will be placed in `generated-nodes/<my-node-name>`.
+
+3. Edit the generated files as needed to comply with innate-in's custom node requirements, then publish to npm:
+   ```bash
+   cd generated-nodes/<my-node-name>
+   npm publish
+   ```
+
+The `generateInnateNode.js` script creates a basic node that can be further customized and linked with a specific innate-in instance.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "configurable-rag",
+  "version": "0.1.0",
+  "description": "Utilities for generating custom innate-in nodes",
+  "main": "index.js",
+  "scripts": {
+    "generate": "node scripts/generateInnateNode.js"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "yaml": "^2.3.0"
+  }
+}

--- a/scripts/generateInnateNode.js
+++ b/scripts/generateInnateNode.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('yaml');
+
+function parseSpec(specPath) {
+  const data = fs.readFileSync(specPath, 'utf8');
+  if (specPath.endsWith('.yaml') || specPath.endsWith('.yml')) {
+    return yaml.parse(data);
+  }
+  return JSON.parse(data);
+}
+
+function generateNode(spec, nodeName, destDir) {
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir, { recursive: true });
+  }
+  const pkg = {
+    name: nodeName,
+    version: '0.0.1',
+    main: 'index.js',
+    description: `Auto-generated node for ${spec.info?.title || nodeName}`,
+    dependencies: {
+      axios: '^1.6.7'
+    }
+  };
+  fs.writeFileSync(path.join(destDir, 'package.json'), JSON.stringify(pkg, null, 2));
+  const index = `const axios = require('axios');\n\nmodule.exports = async function execute(input) {\n  // TODO: map input to API calls\n  console.log('Running ${nodeName} node');\n  // Example GET request\n  const response = await axios.get('${spec.servers?.[0]?.url || 'http://example.com'}');\n  return response.data;\n};\n`;
+  fs.writeFileSync(path.join(destDir, 'index.js'), index);
+}
+
+function main() {
+  const [specPath, nodeName] = process.argv.slice(2);
+  if (!specPath || !nodeName) {
+    console.error('Usage: node generateInnateNode.js <openapi-spec> <node-name>');
+    process.exit(1);
+  }
+  const spec = parseSpec(specPath);
+  const destDir = path.join('generated-nodes', nodeName);
+  generateNode(spec, nodeName, destDir);
+  console.log(`Generated node in ${destDir}`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add script to scaffold a node package from an OpenAPI spec
- document usage in README
- include package.json and `.gitignore`

## Testing
- `npm install`
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_684754da05c4832ea4b152c92d79f936